### PR TITLE
For usage with phergie/phergie-irc-plugin-react-url version 2+

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -15,6 +15,7 @@ use Phergie\Irc\Bot\React\EventQueueInterface as Queue;
 use Phergie\Irc\Plugin\React\Command\CommandEvent as Event;
 use Phergie\Plugin\Http\Request as HttpRequest;
 use Chrismou\Phergie\Plugin\Weather\Provider\WeatherProviderInterface;
+use GuzzleHttp\Message\Response;
 
 /**
  * Plugin class.
@@ -107,8 +108,8 @@ class Plugin extends AbstractPlugin
         $self = $this;
         return new HttpRequest(array(
             'url' => $this->provider->getApiRequestUrl($event),
-            'resolveCallback' => function ($data) use ($self, $event, $queue) {
-                $self->sendIrcResponse($event, $queue, $this->provider->getSuccessLines($event, $data));
+            'resolveCallback' => function (Response $response) use ($self, $event, $queue) {
+                $self->sendIrcResponse($event, $queue, $this->provider->getSuccessLines($event, $response));
             },
             'rejectCallback' => function ($error) use ($self, $event, $queue) {
                 $self->sendIrcResponse($event, $queue, $this->provider->getRejectLines($event, $error));

--- a/src/Provider/OpenWeatherMap.php
+++ b/src/Provider/OpenWeatherMap.php
@@ -75,7 +75,7 @@ class OpenWeatherMap implements WeatherProviderInterface
      */
     public function getSuccessLines(Event $event, $apiResponse)
     {
-        $data = json_decode($apiResponse);
+        $data = json_decode($apiResponse->getBody());
         if (isset($data->name) && $data->name) {
             return array(
                 sprintf(

--- a/src/Provider/Wunderground.php
+++ b/src/Provider/Wunderground.php
@@ -72,7 +72,7 @@ class Wunderground implements WeatherProviderInterface
      */
     public function getSuccessLines(Event $event, $apiResponse)
     {
-        $data = json_decode($apiResponse);
+        $data = json_decode($apiResponse->getBody());
         if (isset($data->current_observation)) {
             $data = $data->current_observation;
             return array(


### PR DESCRIPTION
Similar to the other PRs, For usage with [phergie/phergie-irc-plugin-react-url](https://github.com/phergie/phergie-irc-plugin-react-url) version 2 and higher the response must be handled as Guzzle object.

Tests are similar to the Google tests, where you're passing in raw JSON to test. Tests here will fail because we're now using Guzzle objects instead of raw strings.
